### PR TITLE
Fix: Enforce constant usage across transaction routes

### DIFF
--- a/app/v1/transactions/constants.ts
+++ b/app/v1/transactions/constants.ts
@@ -90,9 +90,13 @@ export const DEVICE_TYPE_CABLE = 'CABLE';
 export const CURRENCY_EUR = 'EUR';
 
 export const RESULT_CODES = {
+  SUCCESS: 0,
   EMV_INITIALIZATION_ERROR: 1010,
   SERVICE_BUSY: 1001,
   INITIALIZATION_SUCCESSFUL: 1000,
   MSG_FORMAT_ERROR: 2,
+  TRANSACTION_NOT_FOUND: 602,
+  INVALID_PARAMS_ERROR: 4, // Corresponds to "MSG_PARAMS_ERROR" in RESPONSE_ERROR
+  REFUND_OPERATION_NOT_ALLOWED: 950, // Corresponds to "Refund Operation not allowed" in RESPONSE_ERROR
   // ... other result codes can be mapped here if needed
 } as const;

--- a/app/v1/transactions/preauth/new/route.ts
+++ b/app/v1/transactions/preauth/new/route.ts
@@ -1,15 +1,15 @@
 import { NextResponse } from 'next/server';
-import { RESPONSE_ERROR, STATUS } from '../../constants';
+import { RESPONSE_ERROR, STATUS, CURRENCY_EUR, RESULT_CODES, DEVICE_TYPE_WIFI, HEADER_X_SOURCE, SOURCE_COMERCIA } from '../../constants';
 import { getTransactionStore } from '../../store';
 import type { PaymentRequest, Transaction } from '../../types';
 import { generateId } from '../../utils/idUtils';
 import { getProcessingTime } from '../../utils/processingUtils';
 
 export async function POST(request: Request) {
-    if (request.headers.get('X-SOURCE') !== 'COMERCIA') {
+    if (request.headers.get(HEADER_X_SOURCE) !== SOURCE_COMERCIA) {
         return NextResponse.json({
-            resultCode: 1010,
-            resultMessage: RESPONSE_ERROR['1010']
+            resultCode: RESULT_CODES.EMV_INITIALIZATION_ERROR,
+            resultMessage: RESPONSE_ERROR[RESULT_CODES.EMV_INITIALIZATION_ERROR.toString()]
         });
     }
 
@@ -19,29 +19,29 @@ export async function POST(request: Request) {
 
         if (!body.amount || !body.orderId) {
             return NextResponse.json({
-                resultCode: 2,
-                resultMessage: RESPONSE_ERROR['2']
+                resultCode: RESULT_CODES.MSG_FORMAT_ERROR,
+                resultMessage: RESPONSE_ERROR[RESULT_CODES.MSG_FORMAT_ERROR.toString()]
             });
         }
 
         if (store.isDeviceBusy()) {
             return NextResponse.json({
-                resultCode: 1001,
-                resultMessage: RESPONSE_ERROR['1001']
+                resultCode: RESULT_CODES.SERVICE_BUSY,
+                resultMessage: RESPONSE_ERROR[RESULT_CODES.SERVICE_BUSY.toString()]
             });
         }
 
-        const deviceType = body.deviceType || 'WIFI';
+        const deviceType = body.deviceType || DEVICE_TYPE_WIFI;
         const processingTime = getProcessingTime(deviceType);
 
         const tx: Transaction = {
             id: generateId(),
             amount: body.amount,
-            currency: "EUR",
+            currency: CURRENCY_EUR,
             status: STATUS.PENDING,
             orderId: body.orderId,
-            resultCode: 1001,
-            resultMessage: RESPONSE_ERROR['1001'],
+            resultCode: RESULT_CODES.SERVICE_BUSY,
+            resultMessage: RESPONSE_ERROR[RESULT_CODES.SERVICE_BUSY.toString()],
             timestamp: new Date().toISOString(),
             tokenization: body.tokenization,
             deviceType: deviceType,
@@ -54,15 +54,15 @@ export async function POST(request: Request) {
 
         return NextResponse.json({
             orderId: body.orderId,
-            resultCode: 1001,
-            resultMessage: RESPONSE_ERROR['1001'],
+            resultCode: RESULT_CODES.SERVICE_BUSY,
+            resultMessage: RESPONSE_ERROR[RESULT_CODES.SERVICE_BUSY.toString()],
             deviceType: tx.deviceType
         });
 
     } catch (error) {
         return NextResponse.json({
-            resultCode: 2,
-            resultMessage: RESPONSE_ERROR['2']
+            resultCode: RESULT_CODES.MSG_FORMAT_ERROR,
+            resultMessage: RESPONSE_ERROR[RESULT_CODES.MSG_FORMAT_ERROR.toString()]
         });
     }
 } 

--- a/app/v1/transactions/status/route.ts
+++ b/app/v1/transactions/status/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { RESPONSE_ERROR, STATUS } from '../constants';
+import { RESPONSE_ERROR, STATUS, RESULT_CODES, HEADER_X_SOURCE, SOURCE_COMERCIA } from '../constants';
 import { getTransactionStore } from '../store';
 
 interface StatusRequest {
@@ -7,10 +7,10 @@ interface StatusRequest {
 }
 
 export async function POST(request: Request) {
-    if (request.headers.get('X-SOURCE') !== 'COMERCIA') {
+    if (request.headers.get(HEADER_X_SOURCE) !== SOURCE_COMERCIA) {
         return NextResponse.json({
-            resultCode: 1010,
-            resultMessage: RESPONSE_ERROR['1010']
+            resultCode: RESULT_CODES.EMV_INITIALIZATION_ERROR,
+            resultMessage: RESPONSE_ERROR[RESULT_CODES.EMV_INITIALIZATION_ERROR.toString()]
         });
     }
 
@@ -20,16 +20,16 @@ export async function POST(request: Request) {
 
         if (!body.orderId) {
             return NextResponse.json({
-                resultCode: 2,
-                resultMessage: RESPONSE_ERROR['2']
+                resultCode: RESULT_CODES.MSG_FORMAT_ERROR,
+                resultMessage: RESPONSE_ERROR[RESULT_CODES.MSG_FORMAT_ERROR.toString()]
             });
         }
 
         const tx = store.getTransaction(body.orderId);
         if (!tx) {
             return NextResponse.json({
-                resultCode: 602,
-                resultMessage: RESPONSE_ERROR['602']
+                resultCode: RESULT_CODES.TRANSACTION_NOT_FOUND,
+                resultMessage: RESPONSE_ERROR[RESULT_CODES.TRANSACTION_NOT_FOUND.toString()]
             });
         }
 
@@ -55,8 +55,8 @@ export async function POST(request: Request) {
                 const updatedTx = {
                     ...tx,
                     status: STATUS.APPROVED,
-                    resultCode: 0,
-                    resultMessage: "Success",
+                    resultCode: RESULT_CODES.SUCCESS,
+                    resultMessage: RESPONSE_ERROR[RESULT_CODES.SUCCESS.toString()],
                     authCode: Math.floor(Math.random() * 1000000).toString().padStart(6, '0')
                 };
                 store.updateTransaction(tx.orderId!, updatedTx);
@@ -70,8 +70,8 @@ export async function POST(request: Request) {
                 const updatedTx = {
                     ...tx,
                     status: STATUS.DECLINED,
-                    resultCode: 950,
-                    resultMessage: RESPONSE_ERROR['950']
+                    resultCode: RESULT_CODES.REFUND_OPERATION_NOT_ALLOWED, // Assuming 950 is for refund declined, or a general decline
+                    resultMessage: RESPONSE_ERROR[RESULT_CODES.REFUND_OPERATION_NOT_ALLOWED.toString()]
                 };
                 store.updateTransaction(tx.orderId!, updatedTx);
                 return NextResponse.json({
@@ -86,16 +86,16 @@ export async function POST(request: Request) {
         // Si aún no ha pasado el tiempo de procesamiento, devolvemos estado ocupado
         return NextResponse.json({
             orderId: tx.orderId,
-            resultCode: 1001,
-            resultMessage: RESPONSE_ERROR['1001'],
+            resultCode: RESULT_CODES.SERVICE_BUSY,
+            resultMessage: RESPONSE_ERROR[RESULT_CODES.SERVICE_BUSY.toString()],
             deviceType: tx.deviceType
         });
 
     } catch (error) {
         console.error('Error processing status request:', error);
         return NextResponse.json({
-            resultCode: 2,
-            resultMessage: RESPONSE_ERROR['2']
+            resultCode: RESULT_CODES.MSG_FORMAT_ERROR,
+            resultMessage: RESPONSE_ERROR[RESULT_CODES.MSG_FORMAT_ERROR.toString()]
         });
     }
 } 


### PR DESCRIPTION
This commit addresses multiple instances where literal values were used for currency, device types, result codes, and result messages within various transaction route handlers and object instantiations. It also standardizes and expands result codes in `constants.ts`.

Key changes:

1.  `constants.ts`:
    *   Added new `RESULT_CODES` for common statuses like `SUCCESS (0)`,
        `TRANSACTION_NOT_FOUND (602)`, `INVALID_PARAMS_ERROR (4)`, and
        `REFUND_OPERATION_NOT_ALLOWED (950)`.
    *   Ensured `RESPONSE_ERROR` includes a mapping for the success
        result code (`"0": "Success"`).

2.  `app/v1/transactions/preauth/new/route.ts`:
    *   Updated to use `CURRENCY_EUR`, `DEVICE_TYPE_WIFI`, and
        `RESULT_CODES` (e.g., `SERVICE_BUSY`, `EMV_INITIALIZATION_ERROR`,
        `MSG_FORMAT_ERROR`) for transaction creation and all responses.

3.  `app/v1/transactions/refund/route.ts`:
    *   Updated to use `CURRENCY_EUR` for transaction creation.
    *   Updated background processing logic to use `RESULT_CODES.SUCCESS`
        and `RESULT_CODES.REFUND_OPERATION_NOT_ALLOWED`.
    *   Standardized error responses to use `RESULT_CODES`.

4.  `app/v1/transactions/preauth/complete/route.ts`:
    *   Updated to use `RESULT_CODES` (e.g., `SUCCESS`,
        `TRANSACTION_NOT_FOUND`, `INVALID_PARAMS_ERROR`,
        `REFUND_OPERATION_NOT_ALLOWED`) for transaction updates and all
        responses.

5.  `app/v1/transactions/status/route.ts`:
    *   Updated simulated processing logic to use `RESULT_CODES.SUCCESS`
        and `RESULT_CODES.REFUND_OPERATION_NOT_ALLOWED`.
    *   Standardized all error and status responses to use `RESULT_CODES`.

These changes significantly improve code consistency, maintainability, and reduce the chances of errors due to magic numbers or strings. This should resolve previous build failures related to type errors and improve overall code quality.